### PR TITLE
Add dependabot (non-preview version)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Now that the dependabot preview was disabled on org-level, let's bring
back the GitHub-builtin version.

Background: The original dependabot company was bought by GitHub and is
now part of GitHubs services. See
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates