### PR TITLE
Readme link-to-other-post content correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,12 @@ and uncompressed data ([PNG](https://en.wikipedia.org/wiki/Portable_Network_Grap
 exceptions though (like photos).
 
 ### Linking to Other Posts
-Example:
-
-Global URL: http://0.0.0.0:4000/introducing-kartothek/
-
-local URL: introducing-kartothek
-
-To link other posts (like above example) in your current post, please use the following local URL syntax instead of a global URL:
 
 ```markdown
-[Another Post](../local URL/)
+[Another Post](<YYYY>-<MM>-<DD>-<another-post>.markdown)
 ```
 
+Note: This link may not work, when running on localhost.
 
 ## How To: Add a new author
 

--- a/_posts/2020-06-19-dask-usage-at-blue-yonder.markdown
+++ b/_posts/2020-06-19-dask-usage-at-blue-yonder.markdown
@@ -144,7 +144,7 @@ For instance, we were able to
 [workers are removed from the cluster](https://github.com/dask/distributed/pull/3366). 
 
 If you are interested in our contributions to Dask and our commitment to the dask community, please
-also check out our blog post [Karlsruhe to D.C. ― a Dask story](../dask-developer-workshop/).
+also check out our blog post [Karlsruhe to D.C. ― a Dask story](2020-05-28-dask-developer-workshop.markdown).
 
 ## Conclusion
 


### PR DESCRIPTION
- Readme file  link-to-other-post content is corrected.

- Link to other post in dask-usage at Blueyonder is corrected.